### PR TITLE
feat: add the relationship between float: left/right and absolute positioning values

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -13,6 +13,12 @@ function flexContainer({style}) {
   return style.display.endsWith("flex");
 }
 
+// The element itself does not generate any boxes, but its children and 
+// pseudo-elements still generate boxes and text runs as normal. 
+function isDisplayContents({style}) {
+  return style.display === "contents";
+}
+
 function multicolContainer({style}) {
   return style.columnWidth === "auto" || style.columnCount === "auto";
 }

--- a/rules
+++ b/rules
@@ -76,7 +76,7 @@ width
 height
 inline-size
 block-size
-  = nonReplacedInlineBox
+  = nonReplacedInlineBox || isDisplayContents
 
 display|inline*
 display|table-*
@@ -84,7 +84,7 @@ display|table-*
 
 float|left
 float|right
-  = flexItem || gridItem
+  = flexItem || gridItem || absPositioned
 
 clip
   = !absPositioned
@@ -115,6 +115,8 @@ text-decoration-color
 text-emphasis-color
   = visitedRule
 
+// TODO: add inset* properties
+// https://www.w3.org/TR/css-position-3/#insets
 top
 right
 bottom
@@ -297,4 +299,4 @@ transition-timing-function
 
 // Floated elements, grid and flex items are blockified. So display:block is not useful.
 display|block
-  = flexItem || gridItem || floated
+  = flexItem || gridItem || floated || absPositioned


### PR DESCRIPTION
Spec: https://www.w3.org/TR/css-position-3/#position-property

> A [position](https://www.w3.org/TR/css-position-3/#propdef-position) value of [absolute](https://www.w3.org/TR/css-position-3/#valdef-position-absolute) or [fixed](https://www.w3.org/TR/css-position-3/#valdef-position-fixed) [blockifies](https://www.w3.org/TR/css-display-3/#blockify) the box and causes [float](https://www.w3.org/TR/CSS2/visuren.html#propdef-float) to compute to [none](https://drafts.csswg.org/css2/#valdef-float-none).

In addition, added the `isDisplayContents()` function.